### PR TITLE
Create space craft class

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -4,6 +4,7 @@ require_relative 'mission_reporter'
 require_relative 'mission_control'
 require_relative 'mission_plan'
 require_relative 'mission'
+require_relative 'space_craft'
 require 'pry'
 
 mission_collections = MissionControl.new(mission: Mission.new)

--- a/mission.rb
+++ b/mission.rb
@@ -3,15 +3,7 @@
 class Mission
   include Cli
 
-  TRAVEL_DISTANCE_IN_KMS = 160
-  PAYLOAD_CAPACITY_IN_KGS = 50_000
-  FUEL_CAPACITY_IN_L = 1_514_100
-  BURN_RATE_IN_L_PER_MIN = 168_233
-  AVERAGE_SPEED_IN_KMS_PER_HR = 1_500
-  SECONDS_PER_HOURS = 3_600
-  SECONDS_PER_MINUTE = 60
-
-  attr_reader :elapsed_time, :distance_traveled
+  attr_reader :elapsed_time
 
   attr_accessor :mission_reporter
 
@@ -25,9 +17,8 @@ class Mission
     @name = name
     @mission_reporter = mission_reporter
     @elapsed_time = 0
-    @distance_traveled = 0
     @aborted = false
-    @speeds_arr = []
+    @rocket = SpaceCraft.new
   end
 
   def continue?
@@ -44,26 +35,6 @@ class Mission
     release_support_structures
     perform_cross_checks
     launch
-  end
-
-  # This method is used to calculate an average current speed rather than just
-  # a fixed value of 1,500 km/h
-  def current_speed
-    @speeds_arr << rand(1400..1600).to_f
-    average_speed = @speeds_arr.sum / @speeds_arr.size
-    average_speed / SECONDS_PER_HOURS
-  end
-
-  def time_to_destination
-    if @distance_traveled < TRAVEL_DISTANCE_IN_KMS
-      (TRAVEL_DISTANCE_IN_KMS - current_distance_traveled) / current_speed
-    else
-      0
-    end
-  end
-
-  def total_fuel_burned
-    BURN_RATE_IN_L_PER_MIN * elapsed_time / SECONDS_PER_MINUTE
   end
 
   def abort!
@@ -114,7 +85,7 @@ class Mission
 
     puts 'Launched!'
     if one_in_number(5)
-      distance_to_explosion = rand(TRAVEL_DISTANCE_IN_KMS)
+      distance_to_explosion = rand(SpaceCraft::TRAVEL_DISTANCE_IN_KMS)
       launch_step while @distance_traveled <= distance_to_explosion
       self.class.explosions += 1
       puts 'Your rocket exploded!'

--- a/mission.rb
+++ b/mission.rb
@@ -8,8 +8,9 @@ class Mission
   attr_accessor :mission_reporter
 
   @aborts = 0
+  @explosions = 0
   class << self
-    attr_accessor :aborts
+    attr_accessor :aborts, :explosions
   end
 
   def initialize(name: nil, mission_reporter: MissionReporter.new(self, SpaceCraft.new(self)))
@@ -58,7 +59,7 @@ class Mission
     # TODO: When mission aborts it doesn't 'reset' when another mission is run
     # and the entire `engage_afterburner` method is skipped on the next
     # `event_sequence` run
-    if one_in_number(99)
+    if one_in_number(3)
       puts 'Mission aborted!'
       self.class.aborts += 1
       name if rename?
@@ -84,7 +85,7 @@ class Mission
     return abort! unless continue? && prompt_user('Launch?')
 
     puts 'Launched!'
-    if one_in_number(99)
+    if one_in_number(5)
       distance_to_explosion = rand(SpaceCraft::TARGET_DISTANCE_IN_KMS)
       launch_step while @space_craft.distance_traveled <= distance_to_explosion
       self.class.explosions += 1

--- a/mission.rb
+++ b/mission.rb
@@ -3,22 +3,22 @@
 class Mission
   include Cli
 
-  attr_reader :elapsed_time
+  attr_reader :elapsed_time, :distance_traveled
 
   attr_accessor :mission_reporter
 
   @aborts = 0
-  @explosions = 0
   class << self
-    attr_accessor :aborts, :explosions
+    attr_accessor :aborts
   end
 
-  def initialize(name: nil, mission_reporter: MissionReporter.new(self))
+  def initialize(name: nil, mission_reporter: MissionReporter.new(self, SpaceCraft.new(self)))
     @name = name
     @mission_reporter = mission_reporter
     @elapsed_time = 0
+    @distance_traveled = 0
     @aborted = false
-    @rocket = SpaceCraft.new
+    @space_craft = SpaceCraft.new(self)
   end
 
   def continue?
@@ -58,7 +58,7 @@ class Mission
     # TODO: When mission aborts it doesn't 'reset' when another mission is run
     # and the entire `engage_afterburner` method is skipped on the next
     # `event_sequence` run
-    if one_in_number(3)
+    if one_in_number(99)
       puts 'Mission aborted!'
       self.class.aborts += 1
       name if rename?
@@ -84,23 +84,20 @@ class Mission
     return abort! unless continue? && prompt_user('Launch?')
 
     puts 'Launched!'
-    if one_in_number(5)
-      distance_to_explosion = rand(SpaceCraft::TRAVEL_DISTANCE_IN_KMS)
-      launch_step while @distance_traveled <= distance_to_explosion
+    if one_in_number(99)
+      distance_to_explosion = rand(SpaceCraft::TARGET_DISTANCE_IN_KMS)
+      launch_step while @space_craft.distance_traveled <= distance_to_explosion
       self.class.explosions += 1
       puts 'Your rocket exploded!'
     else
-      launch_step while @distance_traveled <= TRAVEL_DISTANCE_IN_KMS
+      launch_step while @distance_traveled <= SpaceCraft::TARGET_DISTANCE_IN_KMS
     end
-  end
-
-  def current_distance_traveled
-    current_speed * elapsed_time
   end
 
   def launch_step
     @elapsed_time += 5
-    @distance_traveled = current_distance_traveled
+    @distance_traveled = @space_craft.current_distance_traveled
+    # binding.pry
     mission_reporter.print_status
   end
 end

--- a/mission_control.rb
+++ b/mission_control.rb
@@ -14,7 +14,7 @@ class MissionControl
     attr_accessor :retries, :total_distance_traveled, :total_elapsed_time
   end
 
-  def initialize(mission: Mission.new, mission_reporter: MissionReporter.new(mission))
+  def initialize(mission: Mission.new, mission_reporter: MissionReporter.new(mission, SpaceCraft.new(Mission.new)))
     @missions = []
     @mission = mission
     @mission_reporter = mission_reporter

--- a/mission_plan.rb
+++ b/mission_plan.rb
@@ -12,7 +12,7 @@ class MissionPlan
   def print_plan
     plan = <<~PLAN
       Mission plan:
-        Travel distance: #{SpaceCraft::TRAVEL_DISTANCE_IN_KMS} km
+        Travel distance: #{SpaceCraft::TARGET_DISTANCE_IN_KMS} km
         Payload capacity: #{SpaceCraft::PAYLOAD_CAPACITY_IN_KGS} kg
         Fuel capacity: #{SpaceCraft::FUEL_CAPACITY_IN_L} liters
         Burn rate: #{SpaceCraft::BURN_RATE_IN_L_PER_MIN} liters/min

--- a/mission_plan.rb
+++ b/mission_plan.rb
@@ -12,11 +12,11 @@ class MissionPlan
   def print_plan
     plan = <<~PLAN
       Mission plan:
-        Travel distance: #{Mission::TRAVEL_DISTANCE_IN_KMS} km
-        Payload capacity: #{Mission::PAYLOAD_CAPACITY_IN_KGS} kg
-        Fuel capacity: #{Mission::FUEL_CAPACITY_IN_L} liters
-        Burn rate: #{Mission::BURN_RATE_IN_L_PER_MIN} liters/min
-        Average speed: #{Mission::AVERAGE_SPEED_IN_KMS_PER_HR} km/h
+        Travel distance: #{SpaceCraft::TRAVEL_DISTANCE_IN_KMS} km
+        Payload capacity: #{SpaceCraft::PAYLOAD_CAPACITY_IN_KGS} kg
+        Fuel capacity: #{SpaceCraft::FUEL_CAPACITY_IN_L} liters
+        Burn rate: #{SpaceCraft::BURN_RATE_IN_L_PER_MIN} liters/min
+        Average speed: #{SpaceCraft::AVERAGE_SPEED_IN_KMS_PER_HR} km/h
     PLAN
     puts plan
   end

--- a/mission_reporter.rb
+++ b/mission_reporter.rb
@@ -1,20 +1,21 @@
 # frozen_string_literal: true
 
 class MissionReporter
-  attr_reader :mission
+  attr_reader :mission, :space_craft
 
-  def initialize(mission)
+  def initialize(mission, space_craft)
     @mission = mission
+    @space_craft = space_craft
   end
 
   def print_status
     status = <<~STATUS
       Mission status:
-        Current fuel burn rate: #{Mission::BURN_RATE_IN_L_PER_MIN} liters/min
-        Current speed: #{(mission.current_speed * Mission::SECONDS_PER_HOURS).round(2)} km/h
+        Current fuel burn rate: #{SpaceCraft::BURN_RATE_IN_L_PER_MIN} liters/min
+        Current speed: #{(space_craft.current_speed * SpaceCraft::SECONDS_PER_HOURS).round(2)} km/h
         Elapsed time: #{seconds_to_hms(mission.elapsed_time)}
-        Distance traveled: #{mission.distance_traveled.round(2)} km
-        Time to destination: #{mission.time_to_destination.round(2)} seconds
+        Distance traveled: #{space_craft.distance_traveled.round(2)} km
+        Time to destination: #{space_craft.time_to_destination.round(2)} seconds
     STATUS
     puts status
   end
@@ -25,7 +26,7 @@ class MissionReporter
         Total distance traveled: #{MissionControl.total_distance_traveled.round(2)} km
         Number of aborts and retries: #{Mission.aborts}/#{MissionControl.retries}
         Number of explosions: #{Mission.explosions}
-        Total fuel burned: #{mission.total_fuel_burned.round(0)} liters
+        Total fuel burned: #{space_craft.total_fuel_burned.round(0)} liters
         Flight time: #{seconds_to_hms(MissionControl.total_elapsed_time)}
     SUMMARY
     puts summary

--- a/space_craft.rb
+++ b/space_craft.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+class SpaceCraft
+  TRAVEL_DISTANCE_IN_KMS = 160
+  PAYLOAD_CAPACITY_IN_KGS = 50_000
+  FUEL_CAPACITY_IN_L = 1_514_100
+  BURN_RATE_IN_L_PER_MIN = 168_233
+  AVERAGE_SPEED_IN_KMS_PER_HR = 1_500
+  SECONDS_PER_HOURS = 3_600
+  SECONDS_PER_MINUTE = 60
+
+  attr_reader :distance_traveled
+
+  @explosions = 0
+  class << self
+    attr_accessor :explosions
+  end
+
+  def initialize
+    @distance_traveled = 0
+    @speeds_arr = []
+  end
+
+  # This method is used to calculate an average current speed rather than just
+  # a fixed value of 1,500 km/h
+  def current_speed
+    @speeds_arr << rand(1400..1600).to_f
+    average_speed = @speeds_arr.sum / @speeds_arr.size
+    average_speed / SECONDS_PER_HOURS
+  end
+
+  def time_to_destination
+    if @distance_traveled < TRAVEL_DISTANCE_IN_KMS
+      (TRAVEL_DISTANCE_IN_KMS - current_distance_traveled) / current_speed
+    else
+      0
+    end
+  end
+
+  def total_fuel_burned
+    BURN_RATE_IN_L_PER_MIN * elapsed_time / SECONDS_PER_MINUTE
+  end
+end

--- a/space_craft.rb
+++ b/space_craft.rb
@@ -39,7 +39,7 @@ class SpaceCraft
   end
 
   def total_fuel_burned
-    BURN_RATE_IN_L_PER_MIN * @mission.elapsed_time / SECONDS_PER_MINUTE
+    BURN_RATE_IN_L_PER_MIN * mission.elapsed_time / SECONDS_PER_MINUTE
   end
 
   def current_distance_traveled

--- a/space_craft.rb
+++ b/space_craft.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class SpaceCraft
-  TRAVEL_DISTANCE_IN_KMS = 160
+  TARGET_DISTANCE_IN_KMS = 160
   PAYLOAD_CAPACITY_IN_KGS = 50_000
   FUEL_CAPACITY_IN_L = 1_514_100
   BURN_RATE_IN_L_PER_MIN = 168_233
@@ -9,14 +9,15 @@ class SpaceCraft
   SECONDS_PER_HOURS = 3_600
   SECONDS_PER_MINUTE = 60
 
-  attr_reader :distance_traveled
+  attr_reader :distance_traveled, :mission
 
   @explosions = 0
   class << self
     attr_accessor :explosions
   end
 
-  def initialize
+  def initialize(mission)
+    @mission = mission
     @distance_traveled = 0
     @speeds_arr = []
   end
@@ -30,14 +31,18 @@ class SpaceCraft
   end
 
   def time_to_destination
-    if @distance_traveled < TRAVEL_DISTANCE_IN_KMS
-      (TRAVEL_DISTANCE_IN_KMS - current_distance_traveled) / current_speed
+    if @distance_traveled < TARGET_DISTANCE_IN_KMS
+      (TARGET_DISTANCE_IN_KMS - current_distance_traveled) / current_speed
     else
       0
     end
   end
 
   def total_fuel_burned
-    BURN_RATE_IN_L_PER_MIN * elapsed_time / SECONDS_PER_MINUTE
+    BURN_RATE_IN_L_PER_MIN * @mission.elapsed_time / SECONDS_PER_MINUTE
+  end
+
+  def current_distance_traveled
+    current_speed * @mission.elapsed_time
   end
 end


### PR DESCRIPTION
The `mission` class was doing too much as it controlled the individual mission as well as contained elements which should belong to a space craft.

This PR is to get that change to minimally get that change to work.