### PR TITLE
Set default response to 'y'

### DIFF
--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -3,6 +3,9 @@
 module Cli
   def prompt_user(prompt)
     print "#{prompt} (Y/n) "
-    STDIN.gets.chomp.downcase.start_with?('y')
+    input = STDIN.gets.chomp.downcase
+    input = "y" if input.empty?
+
+    input.start_with?("y")
   end
 end


### PR DESCRIPTION
Currently, the default behaviour is to respond `n` to any `Y/n` prompt.

This PR updates that to set `y` as default response.